### PR TITLE
Fixes required for EKS.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ go get -u github.com/golang/dep/cmd/dep
 
 1. Create a signed cert/key pair and store it in a Kubernetes `secret` that will be consumed by sidecar deployment
 ```
-./install/kubernetes/webhook-create-signed-cert.sh \
+./deployment/webhook-create-signed-cert.sh \
     --service sidecar-injector-webhook-svc \
     --secret sidecar-injector-webhook-certs \
     --namespace default

--- a/deployment/webhook-patch-ca-bundle.sh
+++ b/deployment/webhook-patch-ca-bundle.sh
@@ -6,7 +6,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-export CA_BUNDLE=$(kubectl get configmap -n kube-system extension-apiserver-authentication -o=jsonpath='{.data.client-ca-file}' | base64 | tr -d '\n')
+export CA_BUNDLE=$(kubectl config view --raw --minify --flatten -o jsonpath='{.clusters[].cluster.certificate-authority-data}')
 
 if command -v envsubst >/dev/null 2>&1; then
     envsubst


### PR DESCRIPTION
Under EKS tbe `extension-apiserver-authentication` does not provide a `client-ca-file`. This might be fixed in the future under EKS by suppliying the correct flag to the API server. In the meantime, one can get the CA certificate by extracting it from `kubectl`'s current context.

Also, fix a typo in the README.md file.