### PR TITLE
Fix typo in README.md deploy to deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ admissionregistration.k8s.io/v1beta1
 2. Create a signed cert/key pair and store it in a Kubernetes `secret` that will be consumed by sidecar injector deployment:
 
 ```
-# ./deploy/webhook-create-signed-cert.sh \
+# ./deployment/webhook-create-signed-cert.sh \
     --service sidecar-injector-webhook-svc \
     --secret sidecar-injector-webhook-certs \
     --namespace sidecar-injector

--- a/README.md
+++ b/README.md
@@ -65,19 +65,19 @@ admissionregistration.k8s.io/v1beta1
 3. Patch the `MutatingWebhookConfiguration` by set `caBundle` with correct value from Kubernetes cluster:
 
 ```
-# cat deploy/mutatingwebhook.yaml | \
-    deploy/webhook-patch-ca-bundle.sh > \
-    deploy/mutatingwebhook-ca-bundle.yaml
+# cat deployment/mutatingwebhook.yaml | \
+    deployment/webhook-patch-ca-bundle.sh > \
+    deployment/mutatingwebhook-ca-bundle.yaml
 ```
 
 4. Deploy resources:
 
 ```
-# kubectl create -f deploy/nginxconfigmap.yaml
-# kubectl create -f deploy/configmap.yaml
-# kubectl create -f deploy/deployment.yaml
-# kubectl create -f deploy/service.yaml
-# kubectl create -f deploy/mutatingwebhook-ca-bundle.yaml
+# kubectl create -f deployment/nginxconfigmap.yaml
+# kubectl create -f deployment/configmap.yaml
+# kubectl create -f deployment/deployment.yaml
+# kubectl create -f deployment/service.yaml
+# kubectl create -f deployment/mutatingwebhook-ca-bundle.yaml
 ```
 
 ## Verify


### PR DESCRIPTION
Fix: 
```
# cat deploy/mutatingwebhook.yaml | \
    deploy/webhook-patch-ca-bundle.sh > \
    deploy/mutatingwebhook-ca-bundle.yaml
```